### PR TITLE
Prevent duplicate autogenerated IDs

### DIFF
--- a/jquery.toc.js
+++ b/jquery.toc.js
@@ -43,9 +43,10 @@
             // Set up some automatic IDs if we do not already have them
             $(thisOptions.content).find(thisOptions.headings).attr("id", function (index, attr) {
                 // Generate a valid ID: must start with a letter, and contain only letters and
-                // numbers. All other characters are replaced with underscores.
+                // numbers. All other characters are replaced with underscores. To prevent duplicate
+                // ids, the index is appended.
                 return attr ||
-                    $(this).text().replace(/^[^A-Za-z]*/, "").replace(/[^A-Za-z0-9]+/g, "_");
+                    $(this).text().replace(/^[^A-Za-z]*/, "").replace(/[^A-Za-z0-9]+/g, "_").concat(index);
             }).each(function () {
                 // What level is the current heading?
                 var elem = $(this), level = $.map(headingSelectors, function (selector, index) {


### PR DESCRIPTION
IDs are generated by the text of the headlines. If two different headlines contained the same text, this could lead to duplicate IDs. To prevent this a running index is appended to the IDs.